### PR TITLE
Avoid later wrong recognition of frameno by changing timestamp output format

### DIFF
--- a/nalulib.py
+++ b/nalulib.py
@@ -88,7 +88,7 @@ class NALU:
 
 		def __str__(self):
 				"The string representation of this object"
-				return "%s%8s%5s%5s%5s%14s%12s%12s%8s%13s" % \
+				return "%s%8s%5s%5s%5s%14s%12s%12s%8s%20s" % \
 							(self.startpos, self.length, self.lid, \
 							self.tid, self.qid, self.packettype, self.discardable, \
 							self.truncatable, self.frame_number, self.timestamp)


### PR DESCRIPTION
To avoid later wrong recognition of frameno,timestamp output format changes from 13s% to 20s%,so that space is kept when timestamp is greater or equal than 13 character length